### PR TITLE
ToR Code of Conduct

### DIFF
--- a/code_of_conduct.adoc
+++ b/code_of_conduct.adoc
@@ -1,0 +1,85 @@
+= Contributor Covenant Code of Conduct
+
+== Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+== Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+== Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+== Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+== Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders (the Chair and Deputy Chair) responsible for enforcement. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+== Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+=== 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+=== 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+=== 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+=== 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+== Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by link:https://github.com/mozilla/diversity[Mozilla's code of conduct enforcement ladder].
+
+
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+

--- a/iTC-ToR.adoc
+++ b/iTC-ToR.adoc
@@ -68,22 +68,22 @@ The {iTC-shortname} should be working in manners that promote fair competition a
 If the {iTC-shortname} finds any of the principles not to be appropriate, it should inform the CCDB via the Liaison on what exceptions would be required.
 
 === Code of Conduct
-The {iTC-shortname} draws from the ISO Code of Conduct for the technical Work <<4>>.
+The {iTC-shortname} draws from the ISO Code of Conduct for the technical Work <<4>> and the Contributor Covenant Code of Conduct <<6>>.
 
 [cols=".^1,.^2"]
 |===
 
 |Work for the net benefit of the international community
-|We recognize that the development of International Standards is for the net benefit of the international community, over and above the interests of any individual or organization. We are committed to advancing International Standards within their agreed scope and we will not hinder their development.
+|We recognize that the development of collaborative Protection Profiles is for the net benefit of the international community, over and above the interests of any individual or organization. We are committed to advancing collaborative Protection Profiles within their agreed scope and we will not hinder their development.
 
 |Uphold consensus and governance
-|We will uphold the key principles of International Standardization: consensus, transparency, openness, impartiality, effectiveness, relevance, coherence and the development dimension.
+|We will uphold the key principles of International Standardization in the creation of collaborative Protection Profiles: consensus, transparency, openness, impartiality, effectiveness, relevance, coherence and the development dimension.
 
 |Agree to a clear purpose and scope
-|We are committed to having a clear purpose, scope, objectives, and plan to ensure the timely development of International Standards.
+|We are committed to having a clear purpose, scope, objectives, and plan to ensure the timely development of collaborative Protection Profiles.
 
 |Participate actively and manage effective representation	
-|We agree to actively participate in standards development projects. We will make our contributions to the work through the official procedures in accordance with the ISO/IEC Directives.
+|We agree to actively participate in standards development projects. We will make our contributions to the work through the agreed upon tools and procedures in accordance with the iTC guidance documents.
 
 |Escalate and resolve disputes
 |We will identify and escalate disputes in a timely manner to ensure rapid resolution. We will uphold the agreed dispute resolution processes.
@@ -91,8 +91,8 @@ The {iTC-shortname} draws from the ISO Code of Conduct for the technical Work <<
 |Behave ethically
 |We will act in good faith and with due care and diligence. We will avoid collusive or anticompetitive behaviour. We will promote a culture of fair and ethical behaviour.
 
-|Respect others in meetings
-a|We are committed to respecting others and the professional culture of international standardization within ISO. In meetings we are committed to:
+|Follow a Code of Conduct
+a|We are committed to following a code of conduct in an open, welcoming and inclusive manner. In meetings we are committed to:
 
 * conducting ourselves in a professional manner
 * respecting others and their opinions
@@ -307,3 +307,4 @@ Other SMEs can come from a wide range of background, including government techni
 * [#3]#[3]# Establishing International Technical Communities and collaborative Protection Profiles development, http://www.commoncriteriaportal.org/files/communities/Establishing%20iTCs%20and%20cPP%20development%20-%20v0-7.pdf[Online]
 * [#4]#[4]# ISO CODE OF CONDUCT FOR THE TECHNICAL WORK, https://www.iso.org/publication/PUB100397.html[Online]
 * [#5]#[5]#  DECISIONS AND RECOMMENDATIONS ADOPTED BY THE WTO COMMITTEE ON TECHNICAL BARRIERS TO TRADE SINCE 1 JANUARY 1995, https://docs.wto.org/dol2fe/Pages/FE_Search/FE_S_S006.aspx?Query=(%20@Symbol=%20g/tbt/1/rev*)&Language=ENGLISH&Context=FomerScriptedSearch&languageUIChanged=true#[Online Search]
+* [#6]#[6]# Contributor Covenant Code of Conduct,  https://www.contributor-covenant.org/version/2/0/code_of_conduct/[Online]


### PR DESCRIPTION
So I was looking at some of the contributing guides and one in particular pointed to this site for a code of conduct:

https://www.contributor-covenant.org/version/2/0/code_of_conduct/

I thought this actually looked pretty good, and it can be modified as needed, they just ask for attribution, which is easy. I then looked at the ToR to see what was in there, and generally there is a match overall, but that is much more high level than the covenant.

What really got me though was the language about specific ISO things since the language is taken from the ISO docs. The iTCs aren't actually ISO organizations, so I don't think that should be there, even if the overall goal is something that would be acceptable under the ISO CC spec.

So here I have updated the ToR and also added the code of conduct. I'm somewhat concerned about the blocking sections, but I think that is really just accepted that if someone is not acting in an acceptable fashion that they would be kicked out.